### PR TITLE
Bump minimist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1375,10 +1375,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "mock-require": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "axios": "^0.26.0",
+    "minimist": "^1.2.6",
     "tsc-watch": "^4.6.0",
     "typescipt": "^1.0.0"
   },


### PR DESCRIPTION
Resolves #7, which was only a change to package-lock.json

---

https://github.com/DerekRoberts/github-actor-info/pull/7
Merging this pull request would fix [1 Dependabot alert](https://github.com/DerekRoberts/github-actor-info/security/dependabot?q=is%3Aopen+package%3Aminimist+manifest%3Apackage-lock.json+has%3Apatch) on minimist in [package-lock.json](https://github.com/DerekRoberts/github-actor-info/blob/-/package-lock.json).

Package
Affected versions
Patched version
minimist
(npm)
<= 1.2.5
1.2.6
Minimist <=1.2.5 is vulnerable to Prototype Pollution via file index.js, function setKey() (lines 69-95).